### PR TITLE
Improve release hook

### DIFF
--- a/heroku/release-hook.bash
+++ b/heroku/release-hook.bash
@@ -1,17 +1,29 @@
 #!/bin/bash -eu
 
-EMOJI=""
-if [ "$APP_ENV" = "production" ];then
-    EMOJI=":tada:"
-fi
-
 php artisan migrate --force
 php artisan config:cache
 php artisan route:cache
 php artisan view:cache
 
-if [ "$SLACK_NOTIFY_URL" ];then
-    curl -s -X POST --data-urlencode "payload={\"username\": \"Postdeploy Script\", \"text\": \"[$APP_ENV] Postdeploy script completed. $APP_URL $EMOJI \", \"icon_emoji\": \":rocket:\"}" $SLACK_NOTIFY_URL
+if [ "$SLACK_WEBHOOK_URL" ];then
+    EMOJI=""
+    if [ "$APP_ENV" = "production" ];then
+        EMOJI=":tada:"
+    fi
+
+    # Requirement: `heroku labs:enable runtime-dyno-metadata -a ...`
+    MESSAGE="{
+        \"blocks\": [
+            {
+                \"type\": \"section\",
+                \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"*${APP_URL}* has been deployed to *${APP_ENV}* $EMOJI\nDeployed commit: <${GITHUB_URL}/commit/${HEROKU_SLUG_COMMIT}|${HEROKU_SLUG_COMMIT:0:7}>\"
+                }
+            }
+        ]
+    }"
+    curl -s -X POST -H "Content-type: application/json" --data "$MESSAGE" $SLACK_WEBHOOK_URL
 fi
 
 exit 0


### PR DESCRIPTION
https://stackoverflow.com/questions/14583282/heroku-display-hash-of-current-commit-in-browser#34536363

```
heroku labs:enable runtime-dyno-metadata -a <app name>
```

```
~ $ env
HEROKU_APP_ID:                   9daa2797-e49b-4624-932f-ec3f9688e3da
HEROKU_APP_NAME:                 example-app
HEROKU_DYNO_ID:                  1vac4117-c29f-4312-521e-ba4d8638c1ac
HEROKU_RELEASE_VERSION:          v42
HEROKU_SLUG_COMMIT:              2c3a0b24069af49b3de35b8e8c26765c1dba9ff0
HEROKU_SLUG_DESCRIPTION:         Deploy 2c3a0b2
...
```